### PR TITLE
Fix Age of Empires 2: Definitive Edition

### DIFF
--- a/dll/steam_apps.cpp
+++ b/dll/steam_apps.cpp
@@ -93,7 +93,7 @@ bool Steam_Apps::BIsDlcInstalled( AppId_t appID )
     std::lock_guard<std::recursive_mutex> lock(global_mutex);
     if (appID == 0) return true;
     if (appID == UINT32_MAX) return false; // check Steam_Apps::BIsAppInstalled()
-    if (appID == settings->get_local_game_id().AppID()) return false; //TODO is this correct?
+    if (appID == settings->get_local_game_id().AppID()) return true; //TODO is this correct?
     return settings->hasDLC(appID);
 }
 


### PR DESCRIPTION
This game expects the current app to exist as a owned DLC.

If not true, the game will only load the "Return of Rome" game mode, if that DLC is owned, or load the base game with most options disabled if it is not. Also causes most sounds to not load.

Bellow are videos of what happens without this fix, and with it.

Without this fix (and no DLC): https://github.com/otavepto/gbe_fork/assets/16806072/44eb0dd2-8d95-42e7-acfc-ddbdd37ab644
With this fix (and no DLC): https://github.com/otavepto/gbe_fork/assets/16806072/8bdafe7c-2a4e-409c-a8e5-e706bce8b1e2