### PR TITLE
fix linking errors when build on archlinux

### DIFF
--- a/build_linux_deps.sh
+++ b/build_linux_deps.sh
@@ -289,7 +289,7 @@ wild_zlib_64=(
 echo // building curl lib
 pushd "$deps_dir/curl"
 
-curl_common_defs="-DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_CURL=OFF -DBUILD_STATIC_LIBS=ON -DCURL_USE_OPENSSL=OFF -DCURL_ZLIB=ON"
+curl_common_defs="-DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_CURL=OFF -DBUILD_STATIC_LIBS=ON -DCURL_USE_OPENSSL=OFF -DCURL_ZLIB=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBPSL=OFF -DUSE_LIBIDN2=OFF -DCURL_DISABLE_LDAP=ON"
 
 eval $recreate_32
 eval $cmake_gen32 $curl_common_defs "${wild_zlib_32[@]}" -DCMAKE_SHARED_LINKER_FLAGS_INIT="'$deps_dir/zlib/install32/lib/libz.a'" -DCMAKE_MODULE_LINKER_FLAGS_INIT="'$deps_dir/zlib/install32/lib/libz.a'" -DCMAKE_EXE_LINKER_FLAGS_INIT="'$deps_dir/zlib/install32/lib/libz.a'"


### PR DESCRIPTION
```
  -- Linking all object files from 'build/tmp/linux/generate_interfaces_file_x32_1/' to produce 'build/linux/release/tools/find_interfaces/generate_interfaces_file_x32'
clang++ -std=c++17 -fvisibility=hidden -fexceptions -fno-jump-tables -fno-char8_t -fPIE -m32 -O2 -g0 -pie -Wl,-S -o build/linux/release/tools/find_interfaces/generate_interfaces_file_x32 build/tmp/linux/generate_interfaces_file_x32_1/tools/generate_interfaces/generate_interfaces.o -Lbuild/deps/linux/libssq/build32 -Lbuild/deps/linux/curl/install32/lib -Lbuild/deps/linux/protobuf/install32/lib -Lbuild/deps/linux/zlib/install32/lib -Lbuild/deps/linux/mbedtls/install32/lib -Lbuild/deps/linux/ingame_overlay/install32/lib -Lbuild/deps/linux/ingame_overlay/deps/System/install32/lib -Lbuild/deps/linux/ingame_overlay/deps/mini_detour/install32/lib -Wl,--whole-archive -Wl,-Bstatic -lpthread -ldl -lssq -lz -lcurl -lprotobuf-lite -lmbedcrypto -Wl,-Bdynamic -Wl,--no-whole-archive -Wl,--exclude-libs,ALL

/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(cookie.c.o): in function `Curl_cookie_add':
cookie.c:(.text+0x12a8): undefined reference to `psl_is_cookie_domain_acceptable'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(idn.c.o): in function `Curl_idn_decode':
idn.c:(.text+0x5e): undefined reference to `idn2_check_version'
/usr/bin/ld: idn.c:(.text+0x7e): undefined reference to `idn2_lookup_ul'
/usr/bin/ld: idn.c:(.text+0x96): undefined reference to `idn2_lookup_ul'
/usr/bin/ld: idn.c:(.text+0xba): undefined reference to `idn2_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(idn.c.o): in function `Curl_idn_encode':
idn.c:(.text+0x14d): undefined reference to `idn2_to_unicode_8z8z'
/usr/bin/ld: idn.c:(.text+0x189): undefined reference to `idn2_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(idn.c.o): in function `Curl_free_idnconverted_hostname':
idn.c:(.text+0x1ee): undefined reference to `idn2_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(idn.c.o): in function `Curl_idnconvert_hostname':
idn.c:(.text+0x263): undefined reference to `idn2_check_version'
/usr/bin/ld: idn.c:(.text+0x27a): undefined reference to `idn2_lookup_ul'
/usr/bin/ld: idn.c:(.text+0x291): undefined reference to `idn2_lookup_ul'
/usr/bin/ld: idn.c:(.text+0x2ee): undefined reference to `idn2_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_setup_connection':
openldap.c:(.text+0x6e): undefined reference to `ldap_free_urldesc'
/usr/bin/ld: openldap.c:(.text+0x9e): undefined reference to `ldap_url_parse'
/usr/bin/ld: openldap.c:(.text+0xce): undefined reference to `ldap_free_urldesc'
/usr/bin/ld: openldap.c:(.text+0xff): undefined reference to `ldap_pvt_url_scheme2proto'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_do':
openldap.c:(.text+0x2cb): undefined reference to `ldap_url_parse'
/usr/bin/ld: openldap.c:(.text+0x345): undefined reference to `ldap_search_ext'
/usr/bin/ld: openldap.c:(.text+0x356): undefined reference to `ldap_free_urldesc'
/usr/bin/ld: openldap.c:(.text+0x366): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0x3e6): undefined reference to `ldap_abandon_ext'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_done':
openldap.c:(.text+0x435): undefined reference to `ldap_abandon_ext'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_connect':
openldap.c:(.text+0x4ea): undefined reference to `ldap_init_fd'
/usr/bin/ld: openldap.c:(.text+0x4fa): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0x560): undefined reference to `ldap_set_option'
/usr/bin/ld: openldap.c:(.text+0x56f): undefined reference to `ldap_set_option'
/usr/bin/ld: openldap.c:(.text+0x5cf): undefined reference to `ldap_search_ext'
/usr/bin/ld: openldap.c:(.text+0x674): undefined reference to `ldap_sasl_bind'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_connecting':
openldap.c:(.text+0x7a6): undefined reference to `ldap_msgtype'
/usr/bin/ld: openldap.c:(.text+0x7e6): undefined reference to `ldap_get_dn_ber'
/usr/bin/ld: openldap.c:(.text+0x807): undefined reference to `ldap_get_attribute_ber'
/usr/bin/ld: openldap.c:(.text+0x885): undefined reference to `ber_memfree'
/usr/bin/ld: openldap.c:(.text+0x8a6): undefined reference to `ldap_get_attribute_ber'
/usr/bin/ld: openldap.c:(.text+0x8c6): undefined reference to `ber_free'
/usr/bin/ld: openldap.c:(.text+0x8ee): undefined reference to `ldap_result'
/usr/bin/ld: openldap.c:(.text+0x942): undefined reference to `ldap_parse_result'
/usr/bin/ld: openldap.c:(.text+0x9db): undefined reference to `ldap_parse_sasl_bind_result'
/usr/bin/ld: openldap.c:(.text+0x9f1): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0xa5f): undefined reference to `ldap_parse_sasl_bind_result'
/usr/bin/ld: openldap.c:(.text+0xa75): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0xb4a): undefined reference to `ldap_set_option'
/usr/bin/ld: openldap.c:(.text+0xb56): undefined reference to `ldap_msgfree'
/usr/bin/ld: openldap.c:(.text+0xc45): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0xd59): undefined reference to `ldap_sasl_bind'
/usr/bin/ld: openldap.c:(.text+0xdd0): undefined reference to `ber_bvfree'
/usr/bin/ld: openldap.c:(.text+0xde3): undefined reference to `ldap_msgfree'
/usr/bin/ld: openldap.c:(.text+0xe07): undefined reference to `ldap_abandon_ext'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_disconnect':
openldap.c:(.text+0xe9d): undefined reference to `ldap_unbind_ext'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_perform_auth':
openldap.c:(.text+0xf4d): undefined reference to `ldap_sasl_bind'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_continue_auth':
openldap.c:(.text+0x101d): undefined reference to `ldap_sasl_bind'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_cancel_auth':
openldap.c:(.text+0x10b7): undefined reference to `ldap_sasl_bind'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(openldap.c.o): in function `oldap_recv':
openldap.c:(.text+0x11d6): undefined reference to `ldap_result'
/usr/bin/ld: openldap.c:(.text+0x11fd): undefined reference to `ldap_msgtype'
/usr/bin/ld: openldap.c:(.text+0x123d): undefined reference to `ldap_parse_result'
/usr/bin/ld: openldap.c:(.text+0x1251): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0x1278): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0x12c6): undefined reference to `ldap_get_dn_ber'
/usr/bin/ld: openldap.c:(.text+0x139b): undefined reference to `ldap_get_attribute_ber'
/usr/bin/ld: openldap.c:(.text+0x13b4): undefined reference to `ber_free'
/usr/bin/ld: openldap.c:(.text+0x1454): undefined reference to `ldap_err2string'
/usr/bin/ld: openldap.c:(.text+0x148e): undefined reference to `ldap_memfree'
/usr/bin/ld: openldap.c:(.text+0x149d): undefined reference to `ldap_msgfree'
/usr/bin/ld: openldap.c:(.text+0x1508): undefined reference to `ldap_get_attribute_ber'
/usr/bin/ld: openldap.c:(.text+0x1882): undefined reference to `ber_memfree'
/usr/bin/ld: openldap.c:(.text+0x18a9): undefined reference to `ber_memfree'
/usr/bin/ld: openldap.c:(.text+0x18e9): undefined reference to `ber_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(psl.c.o): in function `Curl_psl_destroy':
psl.c:(.text+0x23): undefined reference to `psl_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(psl.c.o): in function `Curl_psl_use':
psl.c:(.text+0xf6): undefined reference to `psl_latest'
/usr/bin/ld: psl.c:(.text+0x12c): undefined reference to `psl_free'
/usr/bin/ld: psl.c:(.text+0x1a5): undefined reference to `psl_builtin'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(version.c.o): in function `curl_version':
version.c:(.text+0x4f): undefined reference to `idn2_check_version'
/usr/bin/ld: version.c:(.text+0x78): undefined reference to `psl_get_version'
/usr/bin/ld: version.c:(.text+0xc8): undefined reference to `ldap_get_option'
/usr/bin/ld: version.c:(.text+0x14e): undefined reference to `ldap_memfree'
/usr/bin/ld: version.c:(.text+0x15a): undefined reference to `ber_memvfree'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(version.c.o): in function `curl_version_info':
version.c:(.text+0x256): undefined reference to `idn2_check_version'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_do':
libssh2.c:(.text+0x171): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_connect':
libssh2.c:(.text+0x2f2): undefined reference to `libssh2_session_init_ex'
/usr/bin/ld: libssh2.c:(.text+0x323): undefined reference to `libssh2_session_set_read_timeout'
/usr/bin/ld: libssh2.c:(.text+0x362): undefined reference to `libssh2_session_callback_set'
/usr/bin/ld: libssh2.c:(.text+0x379): undefined reference to `libssh2_session_callback_set'
/usr/bin/ld: libssh2.c:(.text+0x3e3): undefined reference to `libssh2_session_flag'
/usr/bin/ld: libssh2.c:(.text+0x41d): undefined reference to `libssh2_knownhost_init'
/usr/bin/ld: libssh2.c:(.text+0x43f): undefined reference to `libssh2_knownhost_readfile'
/usr/bin/ld: libssh2.c:(.text+0x4c2): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: libssh2.c:(.text+0x506): undefined reference to `libssh2_session_free'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_multi_statemach':
libssh2.c:(.text+0x5b2): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `scp_doing':
libssh2.c:(.text+0x662): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_attach':
libssh2.c:(.text+0x751): undefined reference to `libssh2_session_abstract'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `sftp_doing':
libssh2.c:(.text+0x8b2): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `Curl_ssh_init':
libssh2.c:(.text+0x958): undefined reference to `libssh2_init'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `Curl_ssh_cleanup':
libssh2.c:(.text+0x981): undefined reference to `libssh2_exit'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `Curl_ssh_version':
libssh2.c:(.text+0x9ad): undefined reference to `libssh2_version'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_statemach_act':
libssh2.c:(.text+0xaed): undefined reference to `libssh2_session_set_blocking'
/usr/bin/ld: libssh2.c:(.text+0xb46): undefined reference to `libssh2_session_handshake'
/usr/bin/ld: libssh2.c:(.text+0xb78): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0xbe9): undefined reference to `libssh2_userauth_list'
/usr/bin/ld: libssh2.c:(.text+0xcee): undefined reference to `libssh2_userauth_publickey_fromfile_ex'
/usr/bin/ld: libssh2.c:(.text+0xd7a): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0xe2e): undefined reference to `libssh2_userauth_password_ex'
/usr/bin/ld: libssh2.c:(.text+0xea7): undefined reference to `libssh2_agent_init'
/usr/bin/ld: libssh2.c:(.text+0xec3): undefined reference to `libssh2_agent_connect'
/usr/bin/ld: libssh2.c:(.text+0xefe): undefined reference to `libssh2_agent_list_identities'
/usr/bin/ld: libssh2.c:(.text+0xf4d): undefined reference to `libssh2_agent_get_identity'
/usr/bin/ld: libssh2.c:(.text+0x104c): undefined reference to `libssh2_userauth_keyboard_interactive_ex'
/usr/bin/ld: libssh2.c:(.text+0x10f1): undefined reference to `libssh2_sftp_init'
/usr/bin/ld: libssh2.c:(.text+0x1144): undefined reference to `libssh2_sftp_symlink_ex'
/usr/bin/ld: libssh2.c:(.text+0x13e3): undefined reference to `libssh2_sftp_stat_ex'
/usr/bin/ld: libssh2.c:(.text+0x14f2): undefined reference to `libssh2_sftp_stat_ex'
/usr/bin/ld: libssh2.c:(.text+0x152f): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x15d3): undefined reference to `libssh2_sftp_symlink_ex'
/usr/bin/ld: libssh2.c:(.text+0x1610): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x1697): undefined reference to `libssh2_sftp_mkdir_ex'
/usr/bin/ld: libssh2.c:(.text+0x16d4): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x1760): undefined reference to `libssh2_sftp_rename_ex'
/usr/bin/ld: libssh2.c:(.text+0x179d): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x181b): undefined reference to `libssh2_sftp_rmdir_ex'
/usr/bin/ld: libssh2.c:(.text+0x1858): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x18be): undefined reference to `libssh2_sftp_unlink_ex'
/usr/bin/ld: libssh2.c:(.text+0x192a): undefined reference to `libssh2_sftp_statvfs'
/usr/bin/ld: libssh2.c:(.text+0x1a6e): undefined reference to `libssh2_sftp_stat_ex'
/usr/bin/ld: libssh2.c:(.text+0x1b3e): undefined reference to `libssh2_sftp_stat_ex'
/usr/bin/ld: libssh2.c:(.text+0x1c2a): undefined reference to `libssh2_sftp_mkdir_ex'
/usr/bin/ld: libssh2.c:(.text+0x1caa): undefined reference to `libssh2_sftp_open_ex'
/usr/bin/ld: libssh2.c:(.text+0x1d4b): undefined reference to `libssh2_sftp_readdir_ex'
/usr/bin/ld: libssh2.c:(.text+0x1e0b): undefined reference to `libssh2_sftp_symlink_ex'
/usr/bin/ld: libssh2.c:(.text+0x1f13): undefined reference to `libssh2_sftp_close_handle'
/usr/bin/ld: libssh2.c:(.text+0x1fc6): undefined reference to `libssh2_sftp_open_ex'
/usr/bin/ld: libssh2.c:(.text+0x2020): undefined reference to `libssh2_sftp_stat_ex'
/usr/bin/ld: libssh2.c:(.text+0x2054): undefined reference to `libssh2_sftp_close_handle'
/usr/bin/ld: libssh2.c:(.text+0x2090): undefined reference to `libssh2_sftp_close_handle'
/usr/bin/ld: libssh2.c:(.text+0x2124): undefined reference to `libssh2_scp_send64'
/usr/bin/ld: libssh2.c:(.text+0x21ff): undefined reference to `libssh2_scp_recv2'
/usr/bin/ld: libssh2.c:(.text+0x22b1): undefined reference to `libssh2_channel_send_eof'
/usr/bin/ld: libssh2.c:(.text+0x22e3): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x232f): undefined reference to `libssh2_channel_wait_eof'
/usr/bin/ld: libssh2.c:(.text+0x2361): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x23ad): undefined reference to `libssh2_channel_wait_closed'
/usr/bin/ld: libssh2.c:(.text+0x23df): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x242b): undefined reference to `libssh2_channel_free'
/usr/bin/ld: libssh2.c:(.text+0x2467): undefined reference to `libssh2_channel_free'
/usr/bin/ld: libssh2.c:(.text+0x24ad): undefined reference to `libssh2_knownhost_free'
/usr/bin/ld: libssh2.c:(.text+0x24d1): undefined reference to `libssh2_agent_disconnect'
/usr/bin/ld: libssh2.c:(.text+0x24f5): undefined reference to `libssh2_agent_free'
/usr/bin/ld: libssh2.c:(.text+0x25ec): undefined reference to `libssh2_hostkey_hash'
/usr/bin/ld: libssh2.c:(.text+0x2702): undefined reference to `libssh2_hostkey_hash'
/usr/bin/ld: libssh2.c:(.text+0x29e6): undefined reference to `libssh2_agent_userauth'
/usr/bin/ld: libssh2.c:(.text+0x2bd8): undefined reference to `libssh2_userauth_authenticated'
/usr/bin/ld: libssh2.c:(.text+0x2c5d): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x2c82): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x2d5e): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x2d78): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x2e21): undefined reference to `libssh2_sftp_shutdown'
/usr/bin/ld: libssh2.c:(.text+0x2ee2): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x2f07): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x2f6b): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x2f90): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3066): undefined reference to `libssh2_session_disconnect_ex'
/usr/bin/ld: libssh2.c:(.text+0x30ce): undefined reference to `libssh2_session_free'
/usr/bin/ld: libssh2.c:(.text+0x324a): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3291): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x32d0): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x34c9): undefined reference to `libssh2_session_hostkey'
/usr/bin/ld: libssh2.c:(.text+0x3579): undefined reference to `libssh2_knownhost_get'
/usr/bin/ld: libssh2.c:(.text+0x35e7): undefined reference to `libssh2_knownhost_get'
/usr/bin/ld: libssh2.c:(.text+0x3780): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x37d1): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3822): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3873): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x38c4): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o):libssh2.c:(.text+0x3915): more undefined references to `libssh2_session_last_error' follow
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_statemach_act':
libssh2.c:(.text+0x39a9): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x39c3): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3a2e): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3a96): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3bb2): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x3d64): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x3ff7): undefined reference to `libssh2_sftp_open_ex'
/usr/bin/ld: libssh2.c:(.text+0x409e): undefined reference to `libssh2_session_last_errno'
/usr/bin/ld: libssh2.c:(.text+0x41f2): undefined reference to `libssh2_sftp_seek64'
/usr/bin/ld: libssh2.c:(.text+0x42a3): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x446d): undefined reference to `libssh2_session_hostkey'
/usr/bin/ld: libssh2.c:(.text+0x44d9): undefined reference to `libssh2_knownhost_checkp'
/usr/bin/ld: libssh2.c:(.text+0x477b): undefined reference to `libssh2_sftp_last_error'
/usr/bin/ld: libssh2.c:(.text+0x4a11): undefined reference to `libssh2_sftp_seek64'
/usr/bin/ld: libssh2.c:(.text+0x4ae3): undefined reference to `libssh2_sftp_seek64'
/usr/bin/ld: libssh2.c:(.text+0x51fa): undefined reference to `libssh2_version'
/usr/bin/ld: libssh2.c:(.text+0x5266): undefined reference to `libssh2_session_method_pref'
/usr/bin/ld: libssh2.c:(.text+0x5296): undefined reference to `libssh2_session_last_error'
/usr/bin/ld: libssh2.c:(.text+0x53c0): undefined reference to `libssh2_knownhost_del'
/usr/bin/ld: libssh2.c:(.text+0x53e9): undefined reference to `libssh2_knownhost_add'
/usr/bin/ld: libssh2.c:(.text+0x54a3): undefined reference to `libssh2_knownhost_writefile'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `scp_recv':
libssh2.c:(.text+0x5bb7): undefined reference to `libssh2_channel_read_ex'
/usr/bin/ld: libssh2.c:(.text+0x5bd4): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `scp_send':
libssh2.c:(.text+0x5c37): undefined reference to `libssh2_channel_write_ex'
/usr/bin/ld: libssh2.c:(.text+0x5c50): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `sftp_recv':
libssh2.c:(.text+0x5d18): undefined reference to `libssh2_sftp_read'
/usr/bin/ld: libssh2.c:(.text+0x5d31): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `sftp_send':
libssh2.c:(.text+0x5df8): undefined reference to `libssh2_sftp_write'
/usr/bin/ld: libssh2.c:(.text+0x5e11): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: build/deps/linux/curl/install32/lib/libcurl.a(libssh2.c.o): in function `ssh_block_statemach':
libssh2.c:(.text+0x5f6b): undefined reference to `libssh2_session_block_directions'
/usr/bin/ld: libssh2.c:(.text+0x6058): undefined reference to `libssh2_session_block_directions'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

when I build `generate_interfaces_file` `lobby_connect` on archlinux, the error above appeared, add `-DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBPSL=OFF -DUSE_LIBIDN2=OFF -DCURL_DISABLE_LDAP=ON` to `curl_common_defs` seems fixed it.