### PR TITLE
allow loading `.ini` file with the same name as the cold client loader exe name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+* for Windows ColdClientLoader: allow loading `.ini` file with the same name as the loader  
+  ex: if the loader is named `game_cold_loader.exe`, then it will first try to load `game_cold_loader.ini`,  
+  if that doesn't exist, it will fallback to `ColdClientLoader.ini`
+
+---
+
 ## 2024/5/5
 
 * **[Clompress]** update Turkish translation  

--- a/helpers/pe_helpers/pe_helpers.hpp
+++ b/helpers/pe_helpers/pe_helpers.hpp
@@ -5,6 +5,7 @@
 #include <winternl.h>
 
 #include <string>
+#include <string_view>
 
 namespace pe_helpers
 {
@@ -44,7 +45,11 @@ const std::string& get_current_exe_path();
 
 const std::wstring& get_current_exe_path_w();
 
-bool ends_with_i(PUNICODE_STRING target, const std::wstring &query);
+const std::string& get_current_exe_name();
+
+const std::wstring& get_current_exe_name_w();
+
+bool ends_with_i(PUNICODE_STRING target, const std::wstring_view &query);
 
 MEMORY_BASIC_INFORMATION get_mem_page_details(const void* mem);
 

--- a/tools/steamclient_loader/win/ColdClientLoader.cpp
+++ b/tools/steamclient_loader/win/ColdClientLoader.cpp
@@ -12,12 +12,13 @@
 #include <tchar.h>
 #include <stdio.h>
 #include <string>
+#include <filesystem>
 #include <set>
 #include <thread>
 
 
-static const std::wstring IniFile = pe_helpers::get_current_exe_path_w() + L"ColdClientLoader.ini";
-static const std::wstring dbg_file = pe_helpers::get_current_exe_path_w() + L"COLD_LDR_LOG.txt";
+static std::wstring IniFile{};
+static const std::wstring dbg_file = pe_helpers::get_current_exe_path_w() + pe_helpers::get_current_exe_name_w() + L".log";
 constexpr static const char STEAM_UNIVERSE[] = "Public";
 constexpr static const char STEAM_URL_PROTOCOL[] = "URL:steam protocol";
 
@@ -339,9 +340,16 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 {
     dbg_log::init(dbg_file.c_str());
 
+    IniFile = pe_helpers::get_current_exe_path_w() + std::filesystem::path(pe_helpers::get_current_exe_name_w()).stem().wstring() + L".ini";
+    dbg_log::write(L"Searching for configuration file: " + IniFile);
     if (!common_helpers::file_exist(IniFile)) {
-        dbg_log::write(L"Couldn't find the configuration file: " + dbg_file);
-        MessageBoxA(NULL, "Couldn't find the configuration file ColdClientLoader.ini.", "ColdClientLoader", MB_ICONERROR);
+        IniFile = pe_helpers::get_current_exe_path_w() + L"ColdClientLoader.ini";
+        dbg_log::write(L"Searching for configuration file: " + IniFile);
+    }
+
+    if (!common_helpers::file_exist(IniFile)) {
+        dbg_log::write(L"Couldn't find the configuration file");
+        MessageBoxA(NULL, "Couldn't find the configuration file.", "ColdClientLoader", MB_ICONERROR);
         dbg_log::close();
         return 1;
     }


### PR DESCRIPTION
allows placing multiple `cold_client_loader.exe` with different names in the same dir, each having its own `.ini` file.

useful for games with multiple exe, each requiring a different config.

ex:
* `launch_my_game_base.exe` --- `launch_my_game_base.ini`
* `launch_my_game_addon.exe` --- `launch_my_game_addon.ini`

etc...
in these scenarios, the loader is renamed differently

fallback to `ColdClientLoader.ini` (old behavior) for compatibility