### PR TITLE
enhance workflows a little

### DIFF
--- a/.github/workflows/build-gen_emu_config-linux.yml
+++ b/.github/workflows/build-gen_emu_config-linux.yml
@@ -8,19 +8,12 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - 'tools/generate_emu_config/**'
     
   workflow_dispatch:
     # allows manual trigger

--- a/.github/workflows/build-gen_emu_config-win.yml
+++ b/.github/workflows/build-gen_emu_config-win.yml
@@ -8,19 +8,12 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - 'tools/generate_emu_config/**'
     
   workflow_dispatch:
     # allows manual trigger

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -8,19 +8,20 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - '!dev.notes/**'
+      - '!post_build/**'
+      - '!z_original_repo_files/**'
+      - '!sdk/*.txt'
+      - '!LICENSE'
+      # tools
+      - '!tools/generate_emu_config/**'
+      - '!tools/migrate_gse/**'
+      - '!tools/steamclient_loader/linux/**' # these are just shell scripts, not compiled
     
   workflow_dispatch:
     # allows manual trigger
@@ -29,7 +30,6 @@ permissions:
   contents: write
 
 env:
-
   DEPS_CACHE_KEY: emu-deps-linux
   DEPS_CACHE_DIR: build/deps/linux
 

--- a/.github/workflows/build-migrate_gse-linux.yml
+++ b/.github/workflows/build-migrate_gse-linux.yml
@@ -8,19 +8,12 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - 'tools/migrate_gse/**'
     
   workflow_dispatch:
     # allows manual trigger

--- a/.github/workflows/build-migrate_gse-win.yml
+++ b/.github/workflows/build-migrate_gse-win.yml
@@ -8,19 +8,12 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - 'tools/migrate_gse/**'
     
   workflow_dispatch:
     # allows manual trigger

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -8,19 +8,20 @@ on:
     ]
     tags:        
       - release*
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
     
   pull_request:
     branches: [ "dev" ]
-    paths-ignore:
-      - '**/*.md'
-      - 'dev.notes/**'
-      - 'post_build/**'
-      - 'z_original_repo_files/**'
+    paths:
+      - '!**/*.md'
+      - '!dev.notes/**'
+      - '!post_build/**'
+      - '!z_original_repo_files/**'
+      - '!sdk/*.txt'
+      - '!LICENSE'
+      # tools
+      - '!tools/generate_emu_config/**'
+      - '!tools/migrate_gse/**'
+      - '!tools/steamclient_loader/linux/**'
     
   workflow_dispatch:
     # allows manual trigger


### PR DESCRIPTION
* Trigger workflows only for corresponding files/folders, hopefully I didn't miss/break anything
* Allow running workflows unconditionally for branches matching `ci-build*`

The purpose of these branches (`ci-build*`) was to help in automation (currently not used) and for those who cannot setup a dev env at the moment due to any reasons.
Admittedly, `workflow_dispatch` (manual trigger) was a better replacement, so we can remove them if needed.

To mix include & exclude patterns, I used this as a reference since Github doesn't allow both `paths` and `paths-ignore` :/
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
